### PR TITLE
feat: 3ゲーム構成をTinder風スワイプ1ゲームに統合

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.100.1",
         "framer-motion": "^12.34.2",
         "jotai": "^2.18.0",
         "lucide-react": "^0.575.0",
@@ -1287,6 +1288,92 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.1.tgz",
+      "integrity": "sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.100.1.tgz",
+      "integrity": "sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.100.1.tgz",
+      "integrity": "sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.100.1.tgz",
+      "integrity": "sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.100.1.tgz",
+      "integrity": "sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.1.tgz",
+      "integrity": "sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.100.1",
+        "@supabase/functions-js": "2.100.1",
+        "@supabase/postgrest-js": "2.100.1",
+        "@supabase/realtime-js": "2.100.1",
+        "@supabase/storage-js": "2.100.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1666,7 +1753,6 @@
       "version": "20.19.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1697,6 +1783,15 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -4225,6 +4320,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -6820,7 +6924,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -7043,6 +7146,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.100.1",
     "framer-motion": "^12.34.2",
     "jotai": "^2.18.0",
     "lucide-react": "^0.575.0",

--- a/frontend/src/app/api/results/[userId]/route.ts
+++ b/frontend/src/app/api/results/[userId]/route.ts
@@ -1,0 +1,186 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { calculateScores } from '@/lib/analysis/scoring';
+import { generateFeedback } from '@/lib/analysis/feedback';
+import { getMbtiScores } from '@/lib/analysis/mbtiScoreTable';
+import { buildSwipeSummary } from '@/lib/analysis/summary';
+import type { BaselineScores, MouseGameData, SwipeMetrics } from '@/features/game/types';
+
+function getSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'https://placeholder.supabase.co',
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'placeholder',
+  );
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ userId: string }> },
+) {
+  const { userId } = await params;
+
+  const supabase = getSupabase();
+
+  try {
+    // 1. キャッシュ確認
+    const { data: cached } = await supabase
+      .from('analysis_results')
+      .select('*')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (cached) {
+      return NextResponse.json(formatResponse(cached, userId));
+    }
+
+    // 2. ユーザー取得
+    const { data: user, error: userErr } = await supabase
+      .from('users')
+      .select('*')
+      .eq('id', userId)
+      .single();
+    if (userErr || !user) {
+      return NextResponse.json({ error: 'ユーザーが見つかりません' }, { status: 404 });
+    }
+
+    // 3. ゲームログ取得
+    const { data: gameLog, error: gameErr } = await supabase
+      .from('game_logs')
+      .select('raw_data')
+      .eq('user_id', userId)
+      .eq('game_type', 1)
+      .single();
+    if (gameErr || !gameLog) {
+      return NextResponse.json({ error: 'ゲームデータが見つかりません' }, { status: 404 });
+    }
+
+    const gameData = gameLog.raw_data as MouseGameData;
+    const rounds = gameData.rounds as SwipeMetrics[];
+
+    // 4. スコア計算
+    const scores = calculateScores(rounds);
+
+    // 5. ベースライン
+    const baseline: BaselineScores = {
+      caution: user.baseline_caution,
+      calmness: user.baseline_calmness,
+      logic: user.baseline_logic,
+      cooperativeness: user.baseline_coop,
+      positivity: user.baseline_positive,
+    };
+
+    // 6. MBTIブレンド
+    let blended = { ...baseline };
+    let mbtiScores: BaselineScores | null = null;
+    if (user.self_mbti) {
+      mbtiScores = getMbtiScores(user.self_mbti);
+      if (mbtiScores) {
+        blended = {
+          caution: Math.round(baseline.caution * 0.7 + mbtiScores.caution * 0.3),
+          calmness: Math.round(baseline.calmness * 0.7 + mbtiScores.calmness * 0.3),
+          logic: Math.round(baseline.logic * 0.7 + mbtiScores.logic * 0.3),
+          cooperativeness: Math.round(baseline.cooperativeness * 0.7 + mbtiScores.cooperativeness * 0.3),
+          positivity: Math.round(baseline.positivity * 0.7 + mbtiScores.positivity * 0.3),
+        };
+      }
+    }
+
+    // 7. ギャップ
+    const gaps: BaselineScores = {
+      caution: scores.caution - blended.caution,
+      calmness: scores.calmness - blended.calmness,
+      logic: scores.logic - blended.logic,
+      cooperativeness: scores.cooperativeness - blended.cooperativeness,
+      positivity: scores.positivity - blended.positivity,
+    };
+
+    const avgGap =
+      (Math.abs(gaps.caution) +
+        Math.abs(gaps.calmness) +
+        Math.abs(gaps.logic) +
+        Math.abs(gaps.cooperativeness) +
+        Math.abs(gaps.positivity)) /
+      5;
+    const accuracyScore = Math.max(0, Math.round(100 - avgGap));
+
+    // 8. フィードバック
+    const feedback = generateFeedback(scores, gaps);
+
+    // 9. サマリー
+    const summary = buildSwipeSummary(rounds);
+
+    // 10. DB保存
+    const result = {
+      user_id: userId,
+      score_caution: scores.caution,
+      score_calmness: scores.calmness,
+      score_logic: scores.logic,
+      score_coop: scores.cooperativeness,
+      score_positive: scores.positivity,
+      mbti_caution: mbtiScores?.caution ?? null,
+      mbti_calmness: mbtiScores?.calmness ?? null,
+      mbti_logic: mbtiScores?.logic ?? null,
+      mbti_coop: mbtiScores?.cooperativeness ?? null,
+      mbti_positive: mbtiScores?.positivity ?? null,
+      gap_caution: gaps.caution,
+      gap_calmness: gaps.calmness,
+      gap_logic: gaps.logic,
+      gap_coop: gaps.cooperativeness,
+      gap_positive: gaps.positivity,
+      feedback_title: feedback.title,
+      feedback_description: feedback.description,
+      feedback_gap_point: feedback.gapPoint,
+      accuracy_score: accuracyScore,
+      phase_summaries: { phase_1: summary },
+      game_contributions: { game_1: scores },
+    };
+
+    await supabase.from('analysis_results').upsert(result, { onConflict: 'user_id' });
+
+    return NextResponse.json(formatResponse(result, userId));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : '分析に失敗しました';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+function formatResponse(row: Record<string, unknown>, userId: string) {
+  const scores = {
+    caution: row.score_caution as number,
+    calmness: row.score_calmness as number,
+    logic: row.score_logic as number,
+    cooperativeness: row.score_coop as number,
+    positivity: row.score_positive as number,
+  };
+
+  return {
+    userId,
+    selfMbti: null,
+    scores,
+    baseline: scores, // 簡易版
+    mbtiScores:
+      row.mbti_caution != null
+        ? {
+            caution: row.mbti_caution,
+            calmness: row.mbti_calmness,
+            logic: row.mbti_logic,
+            cooperativeness: row.mbti_coop,
+            positivity: row.mbti_positive,
+          }
+        : null,
+    gaps: {
+      caution: row.gap_caution,
+      calmness: row.gap_calmness,
+      logic: row.gap_logic,
+      cooperativeness: row.gap_coop,
+      positivity: row.gap_positive,
+    },
+    feedback: {
+      title: row.feedback_title,
+      description: row.feedback_description,
+      gapPoint: row.feedback_gap_point,
+    },
+    accuracyScore: row.accuracy_score,
+    phaseSummary: (row.phase_summaries as Record<string, string>)?.phase_1 ?? '',
+  };
+}

--- a/frontend/src/app/game/page.tsx
+++ b/frontend/src/app/game/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import GameFlow from '@/features/game/components/GameFlow';
+
+function getStoredUserId(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('real_you_user_id');
+}
+
+export default function GamePage() {
+  const [userId] = useState<string | null>(getStoredUserId);
+
+  useEffect(() => {
+    if (!userId) {
+      window.location.href = '/diagnosis';
+    }
+  }, [userId]);
+
+  if (!userId) {
+    return (
+      <div className="flex h-dvh items-center justify-center bg-gradient-to-br from-purple-900 via-indigo-900 to-blue-900">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-white/30 border-t-white" />
+      </div>
+    );
+  }
+
+  return <GameFlow userId={userId} />;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -102,7 +102,7 @@ export default function TopPage() {
     }
 
     setTimeout(() => {
-      router.push('/games/terms');
+      router.push('/diagnosis');
     }, 800);
 
     setTimeout(() => {

--- a/frontend/src/features/diagnosis/components/BaselineSurvey.tsx
+++ b/frontend/src/features/diagnosis/components/BaselineSurvey.tsx
@@ -4,23 +4,22 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { mbtiAtom } from '@/stores/diagnosis';
-import { game1DataAtom } from '@/stores/games';
 import {
   QUESTIONS,
+  answersToScores,
   type QuestionKey,
   type BaselineAnswers,
   type AnswerOption,
 } from '@/features/diagnosis/types';
 import LoadingScreen from '@/components/common/LoadingScreen';
-import { postRegister, submitGame } from '@/lib/api';
+import { registerUser } from '@/lib/db';
+import { getMbtiScores } from '@/lib/analysis/mbtiScoreTable';
 
-type Status = 'answering' | 'loading' | 'error' | 'success';
+type Status = 'answering' | 'loading' | 'error';
 
-// TODO: UIは仮のものです。
 export default function BaselineSurvey() {
   const router = useRouter();
   const mbti = useAtomValue(mbtiAtom);
-  const game1Data = useAtomValue(game1DataAtom);
 
   const bgmRef = useRef<HTMLAudioElement | null>(null);
 
@@ -30,7 +29,6 @@ export default function BaselineSurvey() {
     audio.play().catch(() => {});
   }, []);
 
-  // BGMの初期化と再生管理
   useEffect(() => {
     const bgm = new Audio('/sounds/start-bgm.mp3');
     bgm.loop = true;
@@ -41,7 +39,6 @@ export default function BaselineSurvey() {
       bgm.play().catch(() => {});
       window.removeEventListener('click', playBGM);
     };
-
     window.addEventListener('click', playBGM);
     playBGM();
 
@@ -63,33 +60,28 @@ export default function BaselineSurvey() {
   const submitToApi = useCallback(
     async (finalAnswers: BaselineAnswers) => {
       setStatus('loading');
+      if (bgmRef.current) bgmRef.current.pause();
 
       try {
-        const result = await postRegister({
-          mbti,
-          baseline_answers: finalAnswers,
-        });
+        const baseScores = answersToScores(finalAnswers);
 
-        localStorage.setItem('user_id', result.user_id);
-
-        if (game1Data) {
-          await submitGame({
-            user_id: result.user_id,
-            game_type: 1,
-            data: game1Data as unknown as Record<string, unknown>,
-          });
+        // MBTI提供時は冷静さ・論理性をMBTI理論値で補完
+        if (mbti) {
+          const mbtiScores = getMbtiScores(mbti);
+          if (mbtiScores) {
+            baseScores.calmness = Math.round(baseScores.calmness * 0.3 + mbtiScores.calmness * 0.7);
+            baseScores.logic = Math.round(baseScores.logic * 0.3 + mbtiScores.logic * 0.7);
+          }
         }
 
-        setStatus('success');
-
-        setTimeout(() => {
-          router.push('/games/helpdesk');
-        }, 2000);
+        const userId = await registerUser({ mbti, baselineScores: baseScores });
+        localStorage.setItem('real_you_user_id', userId);
+        router.push('/game');
       } catch {
         setStatus('error');
       }
     },
-    [mbti, router, game1Data]
+    [mbti, router],
   );
 
   const handleAnswer = (value: AnswerOption) => {
@@ -110,7 +102,7 @@ export default function BaselineSurvey() {
   };
 
   if (status === 'loading') {
-    return <LoadingScreen message="送信中..." />;
+    return <LoadingScreen />;
   }
 
   if (status === 'error') {
@@ -127,22 +119,17 @@ export default function BaselineSurvey() {
     );
   }
 
-  if (status === 'success') {
-    return <LoadingScreen message="ゲームに移動中..." />;
-  }
-
   return (
     <div className="relative w-full max-w-2xl">
-      {/* ヘッダー: タイトル + プログレスバー */}
+      {/* ヘッダー */}
       <div className="mb-0 flex items-start justify-between gap-4">
-        {/* タイトルエリア - メインカードに少し重なる */}
         <div className="relative z-10 flex flex-col">
           <div className="rounded-2xl border-4 border-gray-800 bg-white px-6 py-3 shadow-md">
             <h1 className="text-xl font-bold text-gray-900">質問コーナー</h1>
           </div>
         </div>
 
-        {/* プログレスバー: 5セグメント */}
+        {/* プログレスバー */}
         <div className="flex shrink-0 gap-0.5 rounded-xl border-4 border-gray-800 bg-gray-100 p-1">
           {Array.from({ length: totalQuestions }).map((_, i) => (
             <div
@@ -155,13 +142,12 @@ export default function BaselineSurvey() {
         </div>
       </div>
 
-      {/* メインカード: 質問 + 4択 - タイトルと重なる */}
+      {/* メインカード */}
       <div className="relative -mt-4 rounded-3xl border-4 border-gray-800 bg-white p-6 shadow-lg">
         <p className="mb-6 text-xl font-bold text-gray-900">
           Q{currentIndex + 1}. {currentQuestion.label}
         </p>
 
-        {/* 2x2グリッドの選択肢 */}
         <div className="grid grid-cols-2 gap-4">
           {currentQuestion.options.map((option) => (
             <button

--- a/frontend/src/features/diagnosis/types/index.ts
+++ b/frontend/src/features/diagnosis/types/index.ts
@@ -2,10 +2,8 @@ export type AnswerOption = 'A' | 'B' | 'C' | 'D';
 
 export type QuestionKey =
   | 'q1_caution'
-  | 'q2_calmness'
-  | 'q3_logic'
-  | 'q4_cooperativeness'
-  | 'q5_positivity';
+  | 'q2_cooperativeness'
+  | 'q3_positivity';
 
 export type BaselineAnswers = Record<QuestionKey, AnswerOption>;
 
@@ -32,27 +30,7 @@ export const QUESTIONS: Question[] = [
     ],
   },
   {
-    key: 'q2_calmness',
-    label: '感動的な映画を見終わった直後は？',
-    options: [
-      { value: 'A', label: 'ストーリーの構成を分析する' },
-      { value: 'B', label: '心の中で静かに余韻に浸る' },
-      { value: 'C', label: '「最高だった！」と熱く語る' },
-      { value: 'D', label: '感情移入して思い切り泣く' },
-    ],
-  },
-  {
-    key: 'q3_logic',
-    label: '新しい服を買うときの決め手は？',
-    options: [
-      { value: 'A', label: '着回しやすさや素材の良さ' },
-      { value: 'B', label: '今の流行や使い勝手' },
-      { value: 'C', label: 'デザインの第一印象' },
-      { value: 'D', label: '一目惚れで即決' },
-    ],
-  },
-  {
-    key: 'q4_cooperativeness',
+    key: 'q2_cooperativeness',
     label: '大人数での食事。自分の注文は？',
     options: [
       { value: 'A', label: '全体のバランスを見て合わせる' },
@@ -62,7 +40,7 @@ export const QUESTIONS: Question[] = [
     ],
   },
   {
-    key: 'q5_positivity',
+    key: 'q3_positivity',
     label: '初対面の人が多いパーティーでは？',
     options: [
       { value: 'A', label: '自分からどんどん話しかける' },
@@ -72,3 +50,21 @@ export const QUESTIONS: Question[] = [
     ],
   },
 ];
+
+/** 回答 → 0-100 スコア変換 */
+const ANSWER_SCORE: Record<AnswerOption, number> = {
+  A: 100,
+  B: 75,
+  C: 25,
+  D: 0,
+};
+
+export function answersToScores(answers: BaselineAnswers) {
+  return {
+    caution: ANSWER_SCORE[answers.q1_caution],
+    calmness: 50,           // マウス行動で測定するためデフォルト
+    logic: 50,              // マウス行動で測定するためデフォルト
+    cooperativeness: ANSWER_SCORE[answers.q2_cooperativeness],
+    positivity: ANSWER_SCORE[answers.q3_positivity],
+  };
+}

--- a/frontend/src/features/game/components/CountdownBar.tsx
+++ b/frontend/src/features/game/components/CountdownBar.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+interface Props {
+  durationSec: number;
+  running: boolean;
+}
+
+export default function CountdownBar({ durationSec, running }: Props) {
+  return (
+    <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/20">
+      <motion.div
+        className="h-full rounded-full bg-gradient-to-r from-green-400 via-yellow-400 to-red-400"
+        initial={{ width: '100%' }}
+        animate={running ? { width: '0%' } : { width: '100%' }}
+        transition={
+          running
+            ? { duration: durationSec, ease: 'linear' }
+            : { duration: 0.3 }
+        }
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/game/components/GameFlow.tsx
+++ b/frontend/src/features/game/components/GameFlow.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useRouter } from 'next/navigation';
+import SwipeCard from './SwipeCard';
+import CountdownBar from './CountdownBar';
+import RoundIndicator from './RoundIndicator';
+import { useMouseTracker } from '../hooks/useMouseTracker';
+import { ROUNDS } from '../data/rounds';
+import { submitGameData } from '@/lib/db';
+import type { SwipeMetrics, MouseGameData } from '../types';
+
+type GamePhase = 'intro' | 'playing' | 'submitting';
+
+export default function GameFlow({ userId }: { userId: string }) {
+  const router = useRouter();
+  const [phase, setPhase] = useState<GamePhase>('intro');
+  const [currentRound, setCurrentRound] = useState(0);
+  const [timerRunning, setTimerRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const allMetrics = useRef<SwipeMetrics[]>([]);
+  const gameStart = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tracker = useMouseTracker();
+
+  const round = ROUNDS[currentRound];
+
+  // ---- タイマー管理 ----
+  useEffect(() => {
+    if (phase !== 'playing' || !timerRunning || !round) return;
+
+    timerRef.current = setTimeout(() => {
+      handleSwipe('timeout');
+    }, round.timeLimitSec * 1000);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentRound, timerRunning, phase]);
+
+  // ---- ゲーム開始 ----
+  const startGame = useCallback(() => {
+    gameStart.current = performance.now();
+    setPhase('playing');
+    setCurrentRound(0);
+    tracker.startRound();
+    setTimerRunning(true);
+  }, [tracker]);
+
+  // ---- スワイプ / タイムアウト処理 ----
+  const handleSwipe = useCallback(
+    (direction: 'right' | 'left' | 'timeout') => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setTimerRunning(false);
+
+      const metrics = tracker.finishRound(
+        round.index,
+        round.phase,
+        round.category,
+        direction,
+      );
+      allMetrics.current.push(metrics);
+
+      const nextRound = currentRound + 1;
+      if (nextRound >= ROUNDS.length) {
+        submitResults();
+      } else {
+        setCurrentRound(nextRound);
+        tracker.startRound();
+        setTimerRunning(true);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentRound, round, tracker],
+  );
+
+  // ---- 結果送信 ----
+  const submitResults = useCallback(async () => {
+    setPhase('submitting');
+    const gameData: MouseGameData = {
+      totalDuration: performance.now() - gameStart.current,
+      rounds: allMetrics.current,
+      screenWidth: window.innerWidth,
+      screenHeight: window.innerHeight,
+    };
+    try {
+      await submitGameData(userId, gameData);
+      router.push('/result');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '送信に失敗しました');
+    }
+  }, [userId, router]);
+
+  // ---- Intro 画面 ----
+  if (phase === 'intro') {
+    return (
+      <div className="flex h-dvh flex-col items-center justify-center gap-8 bg-gradient-to-br from-purple-900 via-indigo-900 to-blue-900 px-6 text-white">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-center"
+        >
+          <h1 className="mb-3 text-3xl font-bold">直感スワイプ</h1>
+          <p className="mb-1 text-white/70">画像を見て直感で判断してね</p>
+          <p className="text-sm text-white/50">
+            右スワイプ = 好き / 左スワイプ = スルー
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.5 }}
+          className="flex gap-12 text-5xl"
+        >
+          <span>👈</span>
+          <span>👉</span>
+        </motion.div>
+
+        <motion.button
+          initial={{ opacity: 0, scale: 0.9 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ delay: 0.8 }}
+          onClick={startGame}
+          className="rounded-full bg-white px-10 py-4 text-lg font-bold text-indigo-900 shadow-lg transition hover:scale-105 active:scale-95"
+        >
+          スタート
+        </motion.button>
+      </div>
+    );
+  }
+
+  // ---- Submitting 画面 ----
+  if (phase === 'submitting') {
+    return (
+      <div className="flex h-dvh flex-col items-center justify-center gap-4 bg-gradient-to-br from-purple-900 via-indigo-900 to-blue-900 text-white">
+        {error ? (
+          <>
+            <p className="text-red-300">{error}</p>
+            <button
+              onClick={submitResults}
+              className="rounded-lg bg-white/20 px-6 py-2"
+            >
+              リトライ
+            </button>
+          </>
+        ) : (
+          <>
+            <motion.div
+              animate={{ rotate: 360 }}
+              transition={{ repeat: Infinity, duration: 1, ease: 'linear' }}
+              className="h-10 w-10 rounded-full border-4 border-white/30 border-t-white"
+            />
+            <p className="text-white/70">分析中...</p>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // ---- Playing 画面 ----
+  return (
+    <div className="flex h-dvh flex-col bg-gradient-to-br from-purple-900 via-indigo-900 to-blue-900">
+      {/* ヘッダー */}
+      <div className="flex flex-col items-center gap-3 px-6 pt-6">
+        <RoundIndicator current={currentRound} total={ROUNDS.length} />
+        <CountdownBar
+          durationSec={round.timeLimitSec}
+          running={timerRunning}
+          key={currentRound}
+        />
+        {round.phase === 3 && (
+          <span className="text-xs font-medium text-yellow-300">PRESSURE ROUND</span>
+        )}
+      </div>
+
+      {/* カードエリア */}
+      <div className="relative flex flex-1 items-center justify-center px-6 py-4">
+        <div className="relative aspect-[3/4] w-full max-w-[400px]">
+          <AnimatePresence mode="popLayout">
+            <SwipeCard
+              key={currentRound}
+              imageUrl={round.imageUrl}
+              imageAlt={round.imageAlt}
+              onSwipe={handleSwipe}
+              onPointerMove={tracker.recordPointer}
+              active
+            />
+          </AnimatePresence>
+        </div>
+      </div>
+
+      {/* フッターヒント */}
+      <div className="flex items-center justify-between px-12 pb-8 text-white/50">
+        <span className="text-sm">← スルー</span>
+        <span className="text-xs">{currentRound + 1} / {ROUNDS.length}</span>
+        <span className="text-sm">好き →</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/game/components/RoundIndicator.tsx
+++ b/frontend/src/features/game/components/RoundIndicator.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+interface Props {
+  current: number;
+  total: number;
+}
+
+export default function RoundIndicator({ current, total }: Props) {
+  return (
+    <div className="flex items-center gap-1.5">
+      {Array.from({ length: total }, (_, i) => (
+        <div
+          key={i}
+          className={`h-2 rounded-full transition-all duration-300 ${
+            i < current
+              ? 'w-2 bg-white'
+              : i === current
+                ? 'w-6 bg-white'
+                : 'w-2 bg-white/30'
+          }`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/game/components/SwipeCard.tsx
+++ b/frontend/src/features/game/components/SwipeCard.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { motion, useMotionValue, useTransform, type PanInfo } from 'framer-motion';
+import Image from 'next/image';
+import { useCallback, useRef, type PointerEvent } from 'react';
+
+const SWIPE_THRESHOLD = 120;
+
+interface Props {
+  imageUrl: string;
+  imageAlt: string;
+  onSwipe: (direction: 'left' | 'right') => void;
+  onPointerMove: (x: number, y: number) => void;
+  active: boolean;
+}
+
+export default function SwipeCard({
+  imageUrl,
+  imageAlt,
+  onSwipe,
+  onPointerMove,
+  active,
+}: Props) {
+  const x = useMotionValue(0);
+  const rotate = useTransform(x, [-300, 0, 300], [-18, 0, 18]);
+  const opacity = useTransform(x, [-300, -100, 0, 100, 300], [0.5, 1, 1, 1, 0.5]);
+
+  const leftOpacity = useTransform(x, [-150, -50, 0], [1, 0.4, 0]);
+  const rightOpacity = useTransform(x, [0, 50, 150], [0, 0.4, 1]);
+
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent) => {
+      if (!active) return;
+      const rect = cardRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      onPointerMove(e.clientX - rect.left, e.clientY - rect.top);
+    },
+    [active, onPointerMove],
+  );
+
+  const handleDragEnd = useCallback(
+    (_: MouseEvent | TouchEvent | globalThis.PointerEvent, info: PanInfo) => {
+      if (info.offset.x > SWIPE_THRESHOLD) {
+        onSwipe('right');
+      } else if (info.offset.x < -SWIPE_THRESHOLD) {
+        onSwipe('left');
+      }
+    },
+    [onSwipe],
+  );
+
+  return (
+    <motion.div
+      ref={cardRef}
+      className="absolute inset-0 cursor-grab active:cursor-grabbing"
+      style={{ x, rotate, opacity }}
+      drag={active ? 'x' : false}
+      dragConstraints={{ left: 0, right: 0 }}
+      dragElastic={0.9}
+      onDragEnd={handleDragEnd}
+      onPointerMove={handlePointerMove}
+      whileTap={{ scale: 1.02 }}
+      exit={{
+        x: x.get() > 0 ? 400 : -400,
+        opacity: 0,
+        transition: { duration: 0.3 },
+      }}
+    >
+      <div className="relative h-full w-full overflow-hidden rounded-3xl bg-white shadow-2xl">
+        {/* カード画像 */}
+        <div className="relative h-full w-full">
+          <Image
+            src={imageUrl}
+            alt={imageAlt}
+            fill
+            className="object-cover"
+            sizes="(max-width: 640px) 90vw, 400px"
+            priority
+          />
+        </div>
+
+        {/* スワイプ方向ヒント */}
+        <motion.div
+          className="absolute left-6 top-6 rounded-xl border-4 border-red-400 px-4 py-2"
+          style={{ opacity: leftOpacity }}
+        >
+          <span className="text-2xl font-bold text-red-400">NOPE</span>
+        </motion.div>
+        <motion.div
+          className="absolute right-6 top-6 rounded-xl border-4 border-green-400 px-4 py-2"
+          style={{ opacity: rightOpacity }}
+        >
+          <span className="text-2xl font-bold text-green-400">LIKE</span>
+        </motion.div>
+
+        {/* 画像説明 */}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/60 to-transparent p-6">
+          <p className="text-lg font-medium text-white drop-shadow-lg">{imageAlt}</p>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/features/game/data/rounds.ts
+++ b/frontend/src/features/game/data/rounds.ts
@@ -1,0 +1,93 @@
+import type { RoundConfig } from '../types';
+
+/**
+ * 10ラウンドの定義。
+ * imageUrl はプレースホルダー。実画像を `/public/images/game/` に配置して差し替える。
+ */
+export const ROUNDS: RoundConfig[] = [
+  // ---- Phase 1: ウォームアップ（ベースライン取得） ----
+  {
+    index: 0,
+    phase: 1,
+    imageUrl: '/images/game/r1_landscape_a.webp',
+    imageAlt: '穏やかな湖畔の風景',
+    category: 'neutral',
+    timeLimitSec: 8,
+  },
+  {
+    index: 1,
+    phase: 1,
+    imageUrl: '/images/game/r2_abstract_a.webp',
+    imageAlt: 'カラフルな抽象アート',
+    category: 'neutral',
+    timeLimitSec: 8,
+  },
+  {
+    index: 2,
+    phase: 1,
+    imageUrl: '/images/game/r3_landscape_b.webp',
+    imageAlt: '都会の夜景',
+    category: 'neutral',
+    timeLimitSec: 8,
+  },
+
+  // ---- Phase 2: 本番（性格特性測定） ----
+  {
+    index: 3,
+    phase: 2,
+    imageUrl: '/images/game/r4_group_activity.webp',
+    imageAlt: '友達とバーベキューを楽しむ場面',
+    category: 'social',
+    timeLimitSec: 10,
+  },
+  {
+    index: 4,
+    phase: 2,
+    imageUrl: '/images/game/r5_calm_scene.webp',
+    imageAlt: '静かな読書タイム',
+    category: 'calm_vs_exciting',
+    timeLimitSec: 10,
+  },
+  {
+    index: 5,
+    phase: 2,
+    imageUrl: '/images/game/r6_organized.webp',
+    imageAlt: '整理された美しいデスク',
+    category: 'structured_vs_free',
+    timeLimitSec: 10,
+  },
+  {
+    index: 6,
+    phase: 2,
+    imageUrl: '/images/game/r7_helping.webp',
+    imageAlt: '困っている人を助ける場面',
+    category: 'helping',
+    timeLimitSec: 10,
+  },
+  {
+    index: 7,
+    phase: 2,
+    imageUrl: '/images/game/r8_adventure.webp',
+    imageAlt: '崖からのバンジージャンプ',
+    category: 'risk',
+    timeLimitSec: 10,
+  },
+
+  // ---- Phase 3: プレッシャー（時間圧力下） ----
+  {
+    index: 8,
+    phase: 3,
+    imageUrl: '/images/game/r9_mixed_a.webp',
+    imageAlt: '賑やかなフェスティバル',
+    category: 'mixed',
+    timeLimitSec: 5,
+  },
+  {
+    index: 9,
+    phase: 3,
+    imageUrl: '/images/game/r10_mixed_b.webp',
+    imageAlt: '一人旅の美しい朝焼け',
+    category: 'mixed',
+    timeLimitSec: 5,
+  },
+];

--- a/frontend/src/features/game/hooks/useMouseTracker.ts
+++ b/frontend/src/features/game/hooks/useMouseTracker.ts
@@ -1,0 +1,180 @@
+'use client';
+
+import { useRef, useCallback } from 'react';
+import type { PointerSample, SwipeMetrics } from '../types';
+
+/**
+ * ~60Hz でポインター座標をサンプリングし、
+ * ラウンド終了時に SwipeMetrics を算出するフック。
+ */
+export function useMouseTracker() {
+  const samples = useRef<PointerSample[]>([]);
+  const roundStart = useRef(0);
+  const firstMoveTime = useRef<number | null>(null);
+  const startPos = useRef<{ x: number; y: number } | null>(null);
+
+  const startRound = useCallback(() => {
+    samples.current = [];
+    roundStart.current = performance.now();
+    firstMoveTime.current = null;
+    startPos.current = null;
+  }, []);
+
+  const recordPointer = useCallback((x: number, y: number) => {
+    const t = performance.now();
+    if (startPos.current === null) {
+      startPos.current = { x, y };
+    }
+
+    // 初動検出（10px以上移動）
+    if (firstMoveTime.current === null && startPos.current) {
+      const dx = x - startPos.current.x;
+      const dy = y - startPos.current.y;
+      if (Math.sqrt(dx * dx + dy * dy) > 10) {
+        firstMoveTime.current = t;
+      }
+    }
+
+    samples.current.push({ x, y, t });
+  }, []);
+
+  const finishRound = useCallback(
+    (
+      roundIndex: number,
+      phase: 1 | 2 | 3,
+      category: string,
+      direction: 'right' | 'left' | 'timeout',
+    ): SwipeMetrics => {
+      const now = performance.now();
+      const pts = samples.current;
+      const totalTime = now - roundStart.current;
+      const timeToFirstMove =
+        firstMoveTime.current !== null
+          ? firstMoveTime.current - roundStart.current
+          : totalTime;
+
+      if (pts.length < 2) {
+        return emptyMetrics(roundIndex, phase, category, direction, totalTime, timeToFirstMove);
+      }
+
+      // ---- 速度プロファイル ----
+      const velocities: number[] = [];
+      for (let i = 1; i < pts.length; i++) {
+        const dx = pts[i].x - pts[i - 1].x;
+        const dy = pts[i].y - pts[i - 1].y;
+        const dt = pts[i].t - pts[i - 1].t;
+        if (dt > 0) velocities.push(Math.sqrt(dx * dx + dy * dy) / dt);
+      }
+      const avgVel = velocities.length > 0 ? velocities.reduce((a, b) => a + b, 0) / velocities.length : 0;
+      const peakVel = velocities.length > 0 ? Math.max(...velocities) : 0;
+      const velMean = avgVel;
+      const velVar =
+        velocities.length > 1
+          ? velocities.reduce((s, v) => s + (v - velMean) ** 2, 0) / velocities.length
+          : 0;
+
+      // ---- 軌道逸脱 (MD & AUC) ----
+      const start = pts[0];
+      const end = pts[pts.length - 1];
+      const lineLen = Math.sqrt((end.x - start.x) ** 2 + (end.y - start.y) ** 2);
+      let maxDev = 0;
+      let sumDev = 0;
+      if (lineLen > 1) {
+        for (const p of pts) {
+          const d = pointToLineDist(p.x, p.y, start.x, start.y, end.x, end.y);
+          if (d > maxDev) maxDev = d;
+          sumDev += d;
+        }
+      }
+      const auc = lineLen > 1 ? (sumDev / pts.length) * lineLen : 0;
+
+      // ---- ジッター (100ms窓内90°超方向変化) ----
+      let jitter = 0;
+      for (let i = 2; i < pts.length; i++) {
+        if (pts[i].t - pts[i - 2].t > 100) continue;
+        const a1 = Math.atan2(pts[i - 1].y - pts[i - 2].y, pts[i - 1].x - pts[i - 2].x);
+        const a2 = Math.atan2(pts[i].y - pts[i - 1].y, pts[i].x - pts[i - 1].x);
+        let diff = Math.abs(a2 - a1);
+        if (diff > Math.PI) diff = 2 * Math.PI - diff;
+        if (diff > Math.PI / 2) jitter++;
+      }
+
+      // ---- 方向転換 (左右反転) ----
+      let reversals = 0;
+      let prevDir: 'left' | 'right' | null = null;
+      for (let i = 1; i < pts.length; i++) {
+        const dx = pts[i].x - pts[i - 1].x;
+        if (Math.abs(dx) < 3) continue;
+        const dir = dx > 0 ? 'right' : 'left';
+        if (prevDir !== null && dir !== prevDir) reversals++;
+        prevDir = dir;
+      }
+
+      // ---- 滑らかさ ----
+      const smoothness = pts.length > 2 ? 1 - Math.min(jitter / pts.length, 1) : 0.5;
+
+      // ---- ホバー (初動前の静止時間) ----
+      const hover = timeToFirstMove;
+
+      return {
+        roundIndex,
+        phase,
+        imageCategory: category,
+        swipeDirection: direction,
+        timeToFirstMove,
+        totalSwipeTime: totalTime,
+        swipeVelocity: avgVel,
+        maxDeviation: maxDev,
+        trajectoryAUC: auc,
+        jitterCount: jitter,
+        reversalCount: reversals,
+        peakVelocity: peakVel,
+        velocityVariance: velVar,
+        movementSmoothness: smoothness,
+        hoverDuration: hover,
+      };
+    },
+    [],
+  );
+
+  return { startRound, recordPointer, finishRound };
+}
+
+// ---- ヘルパー ----
+
+function pointToLineDist(
+  px: number, py: number,
+  x1: number, y1: number,
+  x2: number, y2: number,
+): number {
+  const num = Math.abs((y2 - y1) * px - (x2 - x1) * py + x2 * y1 - y2 * x1);
+  const den = Math.sqrt((y2 - y1) ** 2 + (x2 - x1) ** 2);
+  return den === 0 ? 0 : num / den;
+}
+
+function emptyMetrics(
+  roundIndex: number,
+  phase: 1 | 2 | 3,
+  category: string,
+  direction: 'right' | 'left' | 'timeout',
+  totalTime: number,
+  timeToFirstMove: number,
+): SwipeMetrics {
+  return {
+    roundIndex,
+    phase,
+    imageCategory: category,
+    swipeDirection: direction,
+    timeToFirstMove,
+    totalSwipeTime: totalTime,
+    swipeVelocity: 0,
+    maxDeviation: 0,
+    trajectoryAUC: 0,
+    jitterCount: 0,
+    reversalCount: 0,
+    peakVelocity: 0,
+    velocityVariance: 0,
+    movementSmoothness: 0.5,
+    hoverDuration: timeToFirstMove,
+  };
+}

--- a/frontend/src/features/game/types/index.ts
+++ b/frontend/src/features/game/types/index.ts
@@ -1,0 +1,98 @@
+// ---- 5軸スコア（共通） ----
+
+export interface BaselineScores {
+  caution: number;
+  calmness: number;
+  logic: number;
+  cooperativeness: number;
+  positivity: number;
+}
+
+// ---- マウス / スワイプ計測 ----
+
+export interface PointerSample {
+  x: number;
+  y: number;
+  t: number; // ms (performance.now 基準)
+}
+
+export interface SwipeMetrics {
+  roundIndex: number;
+  phase: 1 | 2 | 3;
+  imageCategory: string;
+  swipeDirection: 'right' | 'left' | 'timeout';
+  timeToFirstMove: number;
+  totalSwipeTime: number;
+  swipeVelocity: number;
+  maxDeviation: number;
+  trajectoryAUC: number;
+  jitterCount: number;
+  reversalCount: number;
+  peakVelocity: number;
+  velocityVariance: number;
+  movementSmoothness: number;
+  hoverDuration: number;
+}
+
+export interface MouseGameData {
+  totalDuration: number;
+  rounds: SwipeMetrics[];
+  screenWidth: number;
+  screenHeight: number;
+}
+
+// ---- ラウンド定義 ----
+
+export interface RoundConfig {
+  index: number;
+  phase: 1 | 2 | 3;
+  imageUrl: string;
+  imageAlt: string;
+  category: string;       // 'neutral', 'social', 'calm_vs_exciting', etc.
+  timeLimitSec: number;
+}
+
+// ---- 分析結果 (DB保存用) ----
+
+export interface AnalysisResult {
+  user_id: string;
+  score_caution: number;
+  score_calmness: number;
+  score_logic: number;
+  score_coop: number;
+  score_positive: number;
+  mbti_caution: number | null;
+  mbti_calmness: number | null;
+  mbti_logic: number | null;
+  mbti_coop: number | null;
+  mbti_positive: number | null;
+  gap_caution: number;
+  gap_calmness: number;
+  gap_logic: number;
+  gap_coop: number;
+  gap_positive: number;
+  feedback_title: string;
+  feedback_description: string;
+  feedback_gap_point: string;
+  accuracy_score: number;
+  phase_summaries: { phase_1: string };
+  game_contributions: { game_1: BaselineScores };
+}
+
+// ---- フロントエンド表示用 ----
+
+export interface ResultResponse {
+  userId: string;
+  selfMbti: string | null;
+  scores: BaselineScores;
+  baseline: BaselineScores;
+  mbtiScores: BaselineScores | null;
+  gaps: BaselineScores;
+  feedback: { title: string; description: string; gapPoint: string };
+  accuracyScore: number;
+  phaseSummary: string;
+  details: {
+    featureScores: { axis: string; score: number }[];
+    metrics: { label: string; value: number; average: number }[];
+  };
+}

--- a/frontend/src/features/result/hooks/useResult.ts
+++ b/frontend/src/features/result/hooks/useResult.ts
@@ -2,9 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useSetAtom } from 'jotai';
-import type { ResultResponse } from '@/features/result/types';
 import { resultAtom } from '@/stores/result';
-import { getResult } from '@/lib/api';
 
 const MIN_LOADING_MS = 2000;
 
@@ -12,18 +10,26 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function fetchResult(): Promise<ResultResponse> {
+async function fetchResult() {
   const userId =
-    typeof window !== 'undefined' ? localStorage.getItem('user_id') : null;
+    typeof window !== 'undefined'
+      ? localStorage.getItem('real_you_user_id')
+      : null;
   if (!userId) throw new Error('ユーザーが見つかりません');
-  return await getResult(userId);
+
+  const res = await fetch(`/api/results/${userId}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.error ?? '結果の取得に失敗しました');
+  }
+  return res.json();
 }
 
 export type ResultStatus = 'loading' | 'error' | 'success';
 
 export function useResult() {
   const [status, setStatus] = useState<ResultStatus>('loading');
-  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState('');
   const setResult = useSetAtom(resultAtom);
   const [fetchKey, setFetchKey] = useState(0);
 
@@ -39,7 +45,7 @@ export function useResult() {
       .catch((err: unknown) => {
         if (ignore) return;
         setErrorMessage(
-          err instanceof Error ? err.message : '結果の取得に失敗しました'
+          err instanceof Error ? err.message : '結果の取得に失敗しました',
         );
         setStatus('error');
       });

--- a/frontend/src/lib/analysis/feedback.ts
+++ b/frontend/src/lib/analysis/feedback.ts
@@ -1,0 +1,99 @@
+import type { BaselineScores } from '@/features/game/types';
+
+export function generateFeedback(
+  scores: BaselineScores,
+  gaps: BaselineScores,
+): { title: string; description: string; gapPoint: string } {
+  const gapEntries = Object.entries(gaps).map(([key, value]) => ({
+    key,
+    value,
+    abs: Math.abs(value),
+  }));
+  gapEntries.sort((a, b) => b.abs - a.abs);
+  const maxGap = gapEntries[0];
+
+  if (maxGap.abs <= 10) {
+    return {
+      title: '自己認識の達人',
+      description:
+        'あなたの自己認識と実際の行動にはほとんどズレがありません。自分自身を極めて客観的に把握できています。',
+      gapPoint: 'なし（バランス型）',
+    };
+  }
+
+  const isOverestimated = maxGap.value < 0;
+
+  const feedbackText: Record<
+    string,
+    { over: { title: string; desc: string }; under: { title: string; desc: string } }
+  > = {
+    caution: {
+      over: {
+        title: '予想外の大胆さ',
+        desc: 'あなたは自分を慎重だと思っていましたが、実際の行動では迷いなく大胆な判断を下していました。',
+      },
+      under: {
+        title: '隠れた慎重派',
+        desc: 'あなたは自分を大胆だと思っていましたが、行動ログには石橋を叩いて渡る慎重さが表れています。',
+      },
+    },
+    calmness: {
+      over: {
+        title: '隠れパニックメーカー',
+        desc: 'あなたは冷静なつもりでも、想定外の事態が起きると無意識に焦りが行動に表れてしまうようです。',
+      },
+      under: {
+        title: '氷のメンタル',
+        desc: 'あなたは自分を感情的だと思っていましたが、プレッシャー下でも極めて冷静に処理を行えていました。',
+      },
+    },
+    logic: {
+      over: {
+        title: '直感ドリブン',
+        desc: 'あなたは論理的に考えているつもりでも、いざという時はフィーリングで決定を下すことが多いようです。',
+      },
+      under: {
+        title: '隠れた知性',
+        desc: 'あなたは自分を直感的だと思っていましたが、非常に一貫性のある論理的な判断を下していました。',
+      },
+    },
+    cooperativeness: {
+      over: {
+        title: '孤高のソロプレイヤー',
+        desc: 'あなたは協調的だと思っていましたが、実際には自分の意見を貫く強さを持っています。',
+      },
+      under: {
+        title: '究極のバランサー',
+        desc: 'あなたは自分を独立心が強いと思っていましたが、無意識に周囲の空気を読み調和を重んじています。',
+      },
+    },
+    positivity: {
+      over: {
+        title: '石橋を叩き割る守護者',
+        desc: 'あなたは積極的だと思い込んでいますが、無意識のうちに失敗を恐れ行動が遅れる傾向があります。',
+      },
+      under: {
+        title: '前のめりな挑戦者',
+        desc: 'あなたは自分を消極的だと思っていましたが、チャンスがあれば誰よりも早く行動を起こしています。',
+      },
+    },
+  };
+
+  const axisNames: Record<string, string> = {
+    caution: '慎重さ',
+    calmness: '冷静さ',
+    logic: '論理性',
+    cooperativeness: '協調性',
+    positivity: '積極性',
+  };
+
+  const fb = isOverestimated
+    ? feedbackText[maxGap.key].over
+    : feedbackText[maxGap.key].under;
+
+  return {
+    title: fb.title,
+    description: fb.desc,
+    gapPoint: axisNames[maxGap.key],
+  };
+}

--- a/frontend/src/lib/analysis/mbtiScoreTable.ts
+++ b/frontend/src/lib/analysis/mbtiScoreTable.ts
@@ -1,0 +1,24 @@
+import type { BaselineScores } from '@/features/game/types';
+
+const MBTI_SCORE_TABLE: Record<string, BaselineScores> = {
+  INTJ: { caution: 80, calmness: 85, logic: 95, cooperativeness: 30, positivity: 25 },
+  INTP: { caution: 60, calmness: 80, logic: 90, cooperativeness: 25, positivity: 20 },
+  ENTJ: { caution: 55, calmness: 75, logic: 90, cooperativeness: 45, positivity: 90 },
+  ENTP: { caution: 30, calmness: 60, logic: 80, cooperativeness: 30, positivity: 85 },
+  INFJ: { caution: 75, calmness: 70, logic: 50, cooperativeness: 80, positivity: 30 },
+  INFP: { caution: 65, calmness: 55, logic: 40, cooperativeness: 75, positivity: 20 },
+  ENFJ: { caution: 50, calmness: 65, logic: 45, cooperativeness: 90, positivity: 85 },
+  ENFP: { caution: 25, calmness: 45, logic: 35, cooperativeness: 70, positivity: 90 },
+  ISTJ: { caution: 95, calmness: 85, logic: 80, cooperativeness: 60, positivity: 20 },
+  ISFJ: { caution: 90, calmness: 75, logic: 45, cooperativeness: 85, positivity: 25 },
+  ESTJ: { caution: 70, calmness: 70, logic: 75, cooperativeness: 55, positivity: 80 },
+  ESFJ: { caution: 65, calmness: 55, logic: 40, cooperativeness: 90, positivity: 80 },
+  ISTP: { caution: 50, calmness: 90, logic: 75, cooperativeness: 20, positivity: 30 },
+  ISFP: { caution: 55, calmness: 60, logic: 30, cooperativeness: 65, positivity: 25 },
+  ESTP: { caution: 15, calmness: 55, logic: 60, cooperativeness: 25, positivity: 95 },
+  ESFP: { caution: 10, calmness: 40, logic: 25, cooperativeness: 60, positivity: 95 },
+};
+
+export function getMbtiScores(mbti: string): BaselineScores | null {
+  return MBTI_SCORE_TABLE[mbti.toUpperCase().trim()] ?? null;
+}

--- a/frontend/src/lib/analysis/scoring.ts
+++ b/frontend/src/lib/analysis/scoring.ts
@@ -1,0 +1,138 @@
+/**
+ * マウス軌跡 × スワイプ行動 → 5軸スコアリングエンジン
+ *
+ * Meidenbauer et al. (2023) の知見をベースに、
+ * スワイプ速度・軌道逸脱・ジッター・方向転換・注視時間から
+ * 5軸の性格特性を 0-100 で算出する。
+ */
+import type { SwipeMetrics, BaselineScores } from '@/features/game/types';
+
+// ---- ユーティリティ ----
+
+const clamp = (v: number) => Math.max(0, Math.min(100, v));
+
+const safeScore = (v: number) => Math.min(100, Math.max(0, Math.round(v)));
+
+const linear = (val: number, min: number, max: number) =>
+  clamp(((val - min) / (max - min)) * 100);
+
+const linearInv = (val: number, best: number, worst: number) =>
+  clamp(100 - ((val - best) / (worst - best)) * 100);
+
+const logNorm = (val: number, min: number, max: number) => {
+  const safe = Math.max(min, Math.min(max, val));
+  const num = Math.log(safe + 1) - Math.log(min + 1);
+  const den = Math.log(max + 1) - Math.log(min + 1);
+  return den === 0 ? 0 : clamp((num / den) * 100);
+};
+
+const mean = (arr: number[]) =>
+  arr.length === 0 ? 0 : arr.reduce((a, b) => a + b, 0) / arr.length;
+
+// ---- 軸別スコア算出 ----
+
+function scoreCaution(rounds: SwipeMetrics[]): number {
+  const avgDecisionTime = mean(rounds.map((r) => r.totalSwipeTime));
+  const avgHover = mean(rounds.map((r) => r.hoverDuration));
+  const avgReversals = mean(rounds.map((r) => r.reversalCount));
+  const avgAUC = mean(rounds.map((r) => r.trajectoryAUC));
+
+  const sTime = logNorm(avgDecisionTime, 800, 8000);
+  const sHover = logNorm(avgHover, 200, 3000);
+  const sReversal = linear(avgReversals, 0, 4);
+  const sAUC = logNorm(avgAUC, 500, 20000);
+
+  return safeScore(sTime * 0.3 + sHover * 0.25 + sReversal * 0.25 + sAUC * 0.2);
+}
+
+function scoreCalmness(rounds: SwipeMetrics[]): number {
+  const phase1 = rounds.filter((r) => r.phase === 1);
+  const phase3 = rounds.filter((r) => r.phase === 3);
+  const all = rounds;
+
+  const avgJitter = mean(all.map((r) => r.jitterCount));
+  const avgSmooth = mean(all.map((r) => r.movementSmoothness));
+  const avgVelVar = mean(all.map((r) => r.velocityVariance));
+
+  const baseJitter = mean(phase1.map((r) => r.jitterCount));
+  const pressJitter = mean(phase3.map((r) => r.jitterCount));
+  const jitterDelta = phase3.length > 0 ? pressJitter - baseJitter : 0;
+
+  const sJitter = linearInv(avgJitter, 2, 20);
+  const sSmooth = linear(avgSmooth, 0.3, 0.95);
+  const sVel = linearInv(avgVelVar, 0.01, 0.5);
+  const sStress = linearInv(jitterDelta, 0, 10);
+
+  return safeScore(sJitter * 0.3 + sSmooth * 0.25 + sVel * 0.2 + sStress * 0.25);
+}
+
+function scoreLogic(rounds: SwipeMetrics[]): number {
+  // 同カテゴリ内の選択一貫性を算出
+  const consistency = computeChoiceConsistency(rounds);
+  const avgReversals = mean(rounds.map((r) => r.reversalCount));
+  const avgMD = mean(rounds.map((r) => r.maxDeviation));
+
+  const sConsist = linear(consistency, 0, 100);
+  const sReversal = linearInv(avgReversals, 0, 4);
+  const sDirect = linearInv(avgMD, 20, 200);
+
+  return safeScore(sConsist * 0.4 + sReversal * 0.3 + sDirect * 0.3);
+}
+
+function scoreCooperativeness(rounds: SwipeMetrics[]): number {
+  const socialRounds = rounds.filter(
+    (r) => r.imageCategory === 'social' || r.imageCategory === 'helping',
+  );
+  const rightSwipeRate =
+    socialRounds.length > 0
+      ? socialRounds.filter((r) => r.swipeDirection === 'right').length / socialRounds.length
+      : 0.5;
+
+  const socialHover = mean(socialRounds.map((r) => r.hoverDuration));
+  const allHover = mean(rounds.map((r) => r.hoverDuration));
+  const hoverRatio = allHover > 0 ? socialHover / allHover : 1;
+
+  const sChoice = linear(rightSwipeRate * 100, 0, 100);
+  const sEngage = logNorm(hoverRatio * 100, 50, 200);
+
+  return safeScore(sChoice * 0.6 + sEngage * 0.4);
+}
+
+function scorePositivity(rounds: SwipeMetrics[]): number {
+  const avgVelocity = mean(rounds.map((r) => r.swipeVelocity));
+  const avgDecision = mean(rounds.map((r) => r.totalSwipeTime));
+  const avgFirstMove = mean(rounds.map((r) => r.timeToFirstMove));
+  const timeoutCount = rounds.filter((r) => r.swipeDirection === 'timeout').length;
+
+  const sSpeed = logNorm(avgVelocity * 1000, 100, 2000);
+  const sDecision = linearInv(avgDecision, 500, 6000);
+  const sFirst = linearInv(avgFirstMove, 100, 2000);
+  const sTimeout = linearInv(timeoutCount, 0, 3);
+
+  return safeScore(sSpeed * 0.25 + sDecision * 0.3 + sFirst * 0.25 + sTimeout * 0.2);
+}
+
+// ---- 一貫性スコア ----
+
+function computeChoiceConsistency(rounds: SwipeMetrics[]): number {
+  // Phase2のラウンドをカテゴリでグループ化し、同カテゴリ内で同方向スワイプした割合
+  const phase2 = rounds.filter((r) => r.phase === 2 && r.swipeDirection !== 'timeout');
+  if (phase2.length <= 1) return 50;
+
+  // 全Phase2ラウンドで最頻スワイプ方向と一致する割合
+  const rightCount = phase2.filter((r) => r.swipeDirection === 'right').length;
+  const dominantRate = Math.max(rightCount, phase2.length - rightCount) / phase2.length;
+  return dominantRate * 100;
+}
+
+// ---- メインエントリ ----
+
+export function calculateScores(rounds: SwipeMetrics[]): BaselineScores {
+  return {
+    caution: scoreCaution(rounds),
+    calmness: scoreCalmness(rounds),
+    logic: scoreLogic(rounds),
+    cooperativeness: scoreCooperativeness(rounds),
+    positivity: scorePositivity(rounds),
+  };
+}

--- a/frontend/src/lib/analysis/summary.ts
+++ b/frontend/src/lib/analysis/summary.ts
@@ -1,0 +1,49 @@
+import type { SwipeMetrics } from '@/features/game/types';
+
+const mean = (arr: number[]) =>
+  arr.length === 0 ? 0 : arr.reduce((a, b) => a + b, 0) / arr.length;
+
+export function buildSwipeSummary(rounds: SwipeMetrics[]): string {
+  if (rounds.length === 0) return 'データなし';
+
+  const avgFirst = mean(rounds.map((r) => r.timeToFirstMove));
+  const avgSwipe = mean(rounds.map((r) => r.totalSwipeTime));
+  const totalReversals = rounds.reduce((s, r) => s + r.reversalCount, 0);
+  const timeouts = rounds.filter((r) => r.swipeDirection === 'timeout').length;
+
+  const phase1 = rounds.filter((r) => r.phase === 1);
+  const phase3 = rounds.filter((r) => r.phase === 3);
+  const baseJitter = mean(phase1.map((r) => r.jitterCount));
+  const pressJitter = mean(phase3.map((r) => r.jitterCount));
+
+  const firstText =
+    avgFirst < 500
+      ? '画像を見た瞬間に'
+      : avgFirst < 1500
+        ? '少し眺めてから'
+        : 'じっくり考えてから';
+
+  const speedText =
+    avgSwipe < 1500
+      ? '素早くスワイプしました'
+      : avgSwipe < 3000
+        ? '落ち着いたペースで判断しました'
+        : '慎重に時間をかけて選びました';
+
+  const reversalText =
+    totalReversals >= 5
+      ? `途中で${totalReversals}回も方向を変え、迷いが見られました。`
+      : totalReversals >= 2
+        ? `${totalReversals}回の方向転換がありました。`
+        : '迷いなく一直線に選択しました。';
+
+  const pressureText =
+    phase3.length > 0 && pressJitter > baseJitter * 1.5
+      ? 'プレッシャー下ではマウスの揺れが増加しました。'
+      : 'プレッシャー下でも安定した操作を維持しました。';
+
+  const timeoutText =
+    timeouts > 0 ? `${timeouts}問でタイムアウトしました。` : '';
+
+  return `${firstText}${speedText}。${reversalText}${pressureText}${timeoutText}`;
+}

--- a/frontend/src/lib/db.ts
+++ b/frontend/src/lib/db.ts
@@ -1,0 +1,88 @@
+import { getSupabase } from './supabase';
+import type { BaselineScores, MouseGameData, AnalysisResult } from '@/features/game/types';
+
+// ---- users ----
+
+export async function registerUser(params: {
+  mbti: string | null;
+  baselineScores: BaselineScores;
+}): Promise<string> {
+  const id = crypto.randomUUID();
+  const { error } = await getSupabase().from('users').insert({
+    id,
+    self_mbti: params.mbti,
+    baseline_caution: params.baselineScores.caution,
+    baseline_calmness: params.baselineScores.calmness,
+    baseline_logic: params.baselineScores.logic,
+    baseline_coop: params.baselineScores.cooperativeness,
+    baseline_positive: params.baselineScores.positivity,
+  });
+  if (error) throw new Error(error.message);
+  return id;
+}
+
+// ---- game_logs ----
+
+export async function submitGameData(
+  userId: string,
+  data: MouseGameData,
+): Promise<void> {
+  const { error } = await getSupabase().from('game_logs').upsert(
+    { user_id: userId, game_type: 1, raw_data: data },
+    { onConflict: 'user_id,game_type' },
+  );
+  if (error) throw new Error(error.message);
+}
+
+export async function getGameLog(userId: string) {
+  const { data, error } = await getSupabase()
+    .from('game_logs')
+    .select('raw_data')
+    .eq('user_id', userId)
+    .eq('game_type', 1)
+    .single();
+  if (error) throw new Error(error.message);
+  return data?.raw_data as MouseGameData | null;
+}
+
+// ---- users (read) ----
+
+export async function getUser(userId: string) {
+  const { data, error } = await getSupabase()
+    .from('users')
+    .select('*')
+    .eq('id', userId)
+    .single();
+  if (error) throw new Error(error.message);
+  return {
+    id: data.id as string,
+    selfMbti: data.self_mbti as string | null,
+    baseline: {
+      caution: data.baseline_caution as number,
+      calmness: data.baseline_calmness as number,
+      logic: data.baseline_logic as number,
+      cooperativeness: data.baseline_coop as number,
+      positivity: data.baseline_positive as number,
+    } satisfies BaselineScores,
+  };
+}
+
+// ---- analysis_results ----
+
+export async function getAnalysisResult(userId: string): Promise<AnalysisResult | null> {
+  const { data, error } = await getSupabase()
+    .from('analysis_results')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+  return data as unknown as AnalysisResult;
+}
+
+export async function saveAnalysisResult(result: AnalysisResult): Promise<void> {
+  const { error } = await getSupabase()
+    .from('analysis_results')
+    .upsert(result, { onConflict: 'user_id' });
+  if (error) throw new Error(error.message);
+}

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,0 +1,16 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _client: SupabaseClient<any> | null = null;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getSupabase(): SupabaseClient<any> {
+  if (_client) return _client;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+  if (!url || !key) {
+    throw new Error('Supabase 環境変数が設定されていません');
+  }
+  _client = createClient(url, key);
+  return _client;
+}


### PR DESCRIPTION
## Summary
- 3ゲーム（利用規約・AIヘルプデスク・グループチャット）をTinder風スワイプ1ゲームに統合
- Expressバックエンド廃止 → Supabase直接 + Next.js Route Handler でシンプル化
- Meidenbauer et al. (2023) の研究に基づくマウス軌跡分析で無意識の性格特性を抽出

## Test plan
- [ ] `npm run build` がエラーなく通ること
- [ ] Supabase環境変数設定後、全フロー（トップ→診断→スワイプゲーム→結果）が動作すること
- [ ] プレースホルダー画像を実画像に差し替えること
- [ ] 旧ゲームページ（/games/*）とExpressバックエンドの削除

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ゲーム画面を追加。スワイプカード、カウントダウンバー、ラウンド表示、ポインタトラッキング機能を搭載
  * ベースライン診断を簡略化。質問数を5から3に削減し、より効率的な評価プロセスを実現
  * ゲーム結果分析機能を追加。スコア計算、フィードバック生成、精度表示に対応
  * MBTI統合スコアリング機能を実装。パーソナリティタイプに基づくスコアブレンディングを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->