### PR TITLE
feat: Wave 3 - スワイプUI・マウストラッキング #7

### DIFF
--- a/frontend/src/app/game/page.tsx
+++ b/frontend/src/app/game/page.tsx
@@ -1,0 +1,9 @@
+import { GameFlow } from '@/features/game/components/GameFlow';
+
+export default function GamePage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100">
+      <GameFlow />
+    </main>
+  );
+}

--- a/frontend/src/features/game/components/CardStack.tsx
+++ b/frontend/src/features/game/components/CardStack.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import type { SwipeRoundConfig } from '../data/rounds';
+import { SwipeCard } from './SwipeCard';
+
+interface CardStackProps {
+  currentRound: SwipeRoundConfig;
+  nextRound?: SwipeRoundConfig;
+  onSwipe: (direction: 'left' | 'right') => void;
+  onDragMove?: (x: number, y: number) => void;
+}
+
+export function CardStack({
+  currentRound,
+  nextRound,
+  onSwipe,
+  onDragMove,
+}: CardStackProps) {
+  return (
+    <div className="relative flex items-center justify-center">
+      {/* Next card (behind) */}
+      {nextRound && (
+        <div className="absolute">
+          <motion.div
+            initial={{ scale: 0.92, opacity: 0.5 }}
+            animate={{ scale: 0.92, opacity: 0.5 }}
+            className="pointer-events-none"
+          >
+            <SwipeCard
+              leftImage={nextRound.leftImage}
+              rightImage={nextRound.rightImage}
+              onSwipe={() => {}}
+              disabled
+            />
+          </motion.div>
+        </div>
+      )}
+
+      {/* Current card (on top) */}
+      <AnimatePresence mode="popLayout">
+        <motion.div
+          key={currentRound.roundNumber}
+          initial={{ scale: 0.95, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          exit={{ opacity: 0, scale: 0.8, transition: { duration: 0.2 } }}
+          transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+        >
+          <SwipeCard
+            leftImage={currentRound.leftImage}
+            rightImage={currentRound.rightImage}
+            onSwipe={onSwipe}
+            onDragMove={onDragMove}
+          />
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/features/game/components/CountdownBar.tsx
+++ b/frontend/src/features/game/components/CountdownBar.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+interface CountdownBarProps {
+  timeRemaining: number;
+  totalTime: number;
+}
+
+function getBarColor(ratio: number): string {
+  if (ratio > 0.5) return 'bg-green-500';
+  if (ratio > 0.25) return 'bg-yellow-500';
+  return 'bg-red-500';
+}
+
+export function CountdownBar({ timeRemaining, totalTime }: CountdownBarProps) {
+  const ratio = totalTime > 0 ? timeRemaining / totalTime : 0;
+  const percentage = Math.max(0, Math.min(100, ratio * 100));
+
+  return (
+    <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200">
+      <div
+        className={`h-full rounded-full transition-all duration-300 ease-linear ${getBarColor(ratio)}`}
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/game/components/GameFlow.tsx
+++ b/frontend/src/features/game/components/GameFlow.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect } from 'react';
+import { useSetAtom } from 'jotai';
+import { useSwipeGame } from '../hooks/useSwipeGame';
+import {
+  gameFlowAtom,
+  currentRoundAtom,
+  roundDataAtom,
+  gameDataAtom,
+} from '@/stores/game';
+import { CardStack } from './CardStack';
+import { CountdownBar } from './CountdownBar';
+import { RoundIndicator } from './RoundIndicator';
+import { ROUNDS } from '../data/rounds';
+
+// ========================================
+// Sub-components
+// ========================================
+
+function GameIntro({ onStart }: { readonly onStart: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-8 px-6">
+      <h1 className="text-2xl font-bold text-center">
+        画像えらびゲーム
+      </h1>
+      <div className="max-w-md text-center space-y-4">
+        <p className="text-gray-600">
+          2枚の画像が表示されます。
+          <br />
+          直感で好きな方をスワイプしてください。
+        </p>
+        <p className="text-sm text-gray-400">
+          全10ラウンド・制限時間あり
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onStart}
+        className="px-8 py-3 bg-blue-600 text-white rounded-xl font-semibold hover:bg-blue-700 transition-colors"
+      >
+        はじめる
+      </button>
+    </div>
+  );
+}
+
+function GameSubmitting() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      <div className="w-12 h-12 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
+      <p className="text-gray-600">分析中...</p>
+    </div>
+  );
+}
+
+function GameComplete() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.push('/result');
+  }, [router]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <p className="text-gray-500">結果画面へ移動中...</p>
+    </div>
+  );
+}
+
+// ========================================
+// Main orchestrator
+// ========================================
+
+export function GameFlow() {
+  const {
+    currentRound,
+    roundIndex,
+    totalRounds,
+    timeRemaining,
+    gameState,
+    startGame,
+    handleSwipe,
+    recordPoint,
+  } = useSwipeGame();
+
+  const setGameState = useSetAtom(gameFlowAtom);
+  const setRoundIndex = useSetAtom(currentRoundAtom);
+  const setRounds = useSetAtom(roundDataAtom);
+  const setGameData = useSetAtom(gameDataAtom);
+
+  useEffect(() => {
+    setGameState('intro');
+    setRoundIndex(0);
+    setRounds([]);
+    setGameData(null);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const onDragMove = useCallback(
+    (x: number, y: number) => {
+      recordPoint(x, y);
+    },
+    [recordPoint],
+  );
+
+  const nextRound = ROUNDS[roundIndex + 1];
+
+  switch (gameState) {
+    case 'intro':
+      return <GameIntro onStart={startGame} />;
+    case 'playing':
+      return (
+        <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4">
+          <div className="flex w-full max-w-[480px] items-center justify-between">
+            <RoundIndicator
+              currentRound={currentRound.roundNumber}
+              totalRounds={totalRounds}
+              phase={currentRound.phase}
+            />
+            <span className="text-sm font-medium text-slate-500">
+              {timeRemaining.toFixed(1)}s
+            </span>
+          </div>
+          <div className="w-full max-w-[480px]">
+            <CountdownBar
+              timeRemaining={timeRemaining}
+              totalTime={currentRound.timeLimit}
+            />
+          </div>
+          <CardStack
+            currentRound={currentRound}
+            nextRound={nextRound}
+            onSwipe={handleSwipe}
+            onDragMove={onDragMove}
+          />
+        </div>
+      );
+    case 'submitting':
+      return <GameSubmitting />;
+    case 'done':
+      return <GameComplete />;
+  }
+}

--- a/frontend/src/features/game/components/RoundIndicator.tsx
+++ b/frontend/src/features/game/components/RoundIndicator.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { RoundPhase } from '../types';
+
+interface RoundIndicatorProps {
+  currentRound: number;
+  totalRounds: number;
+  phase: RoundPhase;
+}
+
+const PHASE_CONFIG: Record<RoundPhase, { label: string; color: string }> = {
+  warmup: { label: 'ウォームアップ', color: 'bg-blue-100 text-blue-700' },
+  main: { label: '本番', color: 'bg-green-100 text-green-700' },
+  pressure: { label: 'プレッシャー', color: 'bg-red-100 text-red-700' },
+};
+
+export function RoundIndicator({
+  currentRound,
+  totalRounds,
+  phase,
+}: RoundIndicatorProps) {
+  const config = PHASE_CONFIG[phase];
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-lg font-bold text-slate-700">
+        {currentRound} / {totalRounds}
+      </span>
+      <span
+        className={`rounded-full px-3 py-0.5 text-xs font-semibold ${config.color}`}
+      >
+        {config.label}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/features/game/components/SwipeCard.tsx
+++ b/frontend/src/features/game/components/SwipeCard.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import Image from 'next/image';
+import { motion, useMotionValue, useTransform } from 'framer-motion';
+import type { PanInfo } from 'framer-motion';
+import { useCallback } from 'react';
+
+const SWIPE_THRESHOLD = 100;
+
+interface SwipeCardProps {
+  leftImage: { path: string; label: string };
+  rightImage: { path: string; label: string };
+  onSwipe: (direction: 'left' | 'right') => void;
+  onDragMove?: (x: number, y: number) => void;
+  disabled?: boolean;
+}
+
+export function SwipeCard({
+  leftImage,
+  rightImage,
+  onSwipe,
+  onDragMove,
+  disabled = false,
+}: SwipeCardProps) {
+  const x = useMotionValue(0);
+  const rotate = useTransform(x, [-300, 0, 300], [-15, 0, 15]);
+  const leftIndicatorOpacity = useTransform(x, [-200, -50, 0], [1, 0.3, 0]);
+  const rightIndicatorOpacity = useTransform(x, [0, 50, 200], [0, 0.3, 1]);
+
+  const handleDrag = useCallback(
+    (_: unknown, info: PanInfo) => {
+      onDragMove?.(info.point.x, info.point.y);
+    },
+    [onDragMove],
+  );
+
+  const handleDragEnd = useCallback(
+    (_: unknown, info: PanInfo) => {
+      const offset = info.offset.x;
+      if (Math.abs(offset) > SWIPE_THRESHOLD) {
+        onSwipe(offset > 0 ? 'right' : 'left');
+      }
+    },
+    [onSwipe],
+  );
+
+  return (
+    <motion.div
+      style={{ x, rotate }}
+      drag={disabled ? false : 'x'}
+      dragConstraints={{ left: 0, right: 0 }}
+      dragElastic={0.8}
+      onDrag={handleDrag}
+      onDragEnd={handleDragEnd}
+      className="relative w-[320px] max-w-[480px] cursor-grab rounded-2xl bg-white shadow-xl active:cursor-grabbing sm:w-[420px] md:w-[480px]"
+    >
+      {/* Left swipe indicator */}
+      <motion.div
+        style={{ opacity: leftIndicatorOpacity }}
+        className="pointer-events-none absolute left-4 top-4 z-10 rounded-lg border-2 border-red-400 bg-red-50 px-3 py-1"
+      >
+        <span className="text-sm font-bold text-red-500">スルー</span>
+      </motion.div>
+
+      {/* Right swipe indicator */}
+      <motion.div
+        style={{ opacity: rightIndicatorOpacity }}
+        className="pointer-events-none absolute right-4 top-4 z-10 rounded-lg border-2 border-blue-400 bg-blue-50 px-3 py-1"
+      >
+        <span className="text-sm font-bold text-blue-500">好き</span>
+      </motion.div>
+
+      {/* Image pair */}
+      <div className="flex gap-2 p-4">
+        <div className="flex flex-1 flex-col items-center gap-2">
+          <div className="relative aspect-[4/3] w-full overflow-hidden rounded-lg">
+            <Image
+              src={leftImage.path}
+              alt={leftImage.label}
+              fill
+              className="object-cover"
+              sizes="(max-width: 640px) 140px, 200px"
+            />
+          </div>
+          <span className="text-xs font-medium text-slate-600">
+            {leftImage.label}
+          </span>
+        </div>
+        <div className="flex flex-1 flex-col items-center gap-2">
+          <div className="relative aspect-[4/3] w-full overflow-hidden rounded-lg">
+            <Image
+              src={rightImage.path}
+              alt={rightImage.label}
+              fill
+              className="object-cover"
+              sizes="(max-width: 640px) 140px, 200px"
+            />
+          </div>
+          <span className="text-xs font-medium text-slate-600">
+            {rightImage.label}
+          </span>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/features/game/components/SwipeHint.tsx
+++ b/frontend/src/features/game/components/SwipeHint.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+interface SwipeHintProps {
+  direction: 'left' | 'right' | null;
+  intensity: number;
+}
+
+export function SwipeHint({ direction, intensity }: SwipeHintProps) {
+  return (
+    <div className="pointer-events-none flex w-full justify-between px-4">
+      <motion.div
+        animate={{ opacity: direction === 'left' ? intensity : 0 }}
+        transition={{ duration: 0.1 }}
+        className="flex items-center gap-1 text-lg font-bold text-red-400"
+      >
+        <span>←</span>
+        <span>スルー</span>
+      </motion.div>
+      <motion.div
+        animate={{ opacity: direction === 'right' ? intensity : 0 }}
+        transition={{ duration: 0.1 }}
+        className="flex items-center gap-1 text-lg font-bold text-blue-400"
+      >
+        <span>好き</span>
+        <span>→</span>
+      </motion.div>
+    </div>
+  );
+}

--- a/frontend/src/features/game/hooks/useMouseTracker.ts
+++ b/frontend/src/features/game/hooks/useMouseTracker.ts
@@ -1,0 +1,219 @@
+'use client';
+
+import { useRef, useCallback } from 'react';
+import type { SwipeMetrics, TrajectoryPoint } from '@/features/game/types';
+
+export interface UseMouseTrackerReturn {
+  startTracking: () => void;
+  stopTracking: () => SwipeMetrics;
+  recordPoint: (x: number, y: number) => void;
+  getTrajectory: () => readonly TrajectoryPoint[];
+}
+
+/**
+ * Track pointer movements during each round and calculate SwipeMetrics.
+ * Uses refs to avoid re-renders during tracking.
+ */
+export function useMouseTracker(): UseMouseTrackerReturn {
+  const trajectoryRef = useRef<TrajectoryPoint[]>([]);
+  const roundStartRef = useRef<number>(0);
+  const firstMoveTimestampRef = useRef<number | null>(null);
+
+  const startTracking = useCallback(() => {
+    trajectoryRef.current = [];
+    roundStartRef.current = performance.now();
+    firstMoveTimestampRef.current = null;
+  }, []);
+
+  const recordPoint = useCallback((x: number, y: number) => {
+    const now = performance.now();
+    const timestamp = now - roundStartRef.current;
+
+    if (firstMoveTimestampRef.current === null) {
+      firstMoveTimestampRef.current = now;
+    }
+
+    const points = trajectoryRef.current;
+    let velocity = 0;
+    if (points.length > 0) {
+      const prev = points[points.length - 1];
+      const dt = timestamp - prev.timestamp;
+      if (dt > 0) {
+        const dx = x - prev.x;
+        const dy = y - prev.y;
+        velocity = Math.sqrt(dx * dx + dy * dy) / dt;
+      }
+    }
+
+    points.push({ x, y, timestamp, velocity });
+  }, []);
+
+  const getTrajectory = useCallback(
+    (): readonly TrajectoryPoint[] => [...trajectoryRef.current],
+    []
+  );
+
+  const stopTracking = useCallback((): SwipeMetrics => {
+    const points = trajectoryRef.current;
+    const now = performance.now();
+    const roundStart = roundStartRef.current;
+    const firstMove = firstMoveTimestampRef.current;
+
+    const timeToFirstMove = firstMove !== null ? firstMove - roundStart : now - roundStart;
+    const totalSwipeTime = firstMove !== null ? now - firstMove : 0;
+
+    if (points.length < 2) {
+      return buildEmptyMetrics(timeToFirstMove, totalSwipeTime);
+    }
+
+    const velocities = points
+      .map((p) => p.velocity ?? 0)
+      .filter((v) => v > 0);
+
+    const peakVelocity = velocities.length > 0
+      ? Math.max(...velocities)
+      : 0;
+
+    const avgVelocity = velocities.length > 0
+      ? velocities.reduce((a, b) => a + b, 0) / velocities.length
+      : 0;
+
+    const velocityVariance = computeVariance(velocities);
+
+    const { maxDeviation, trajectoryAUC } = computeDeviationMetrics(points);
+    const jitterCount = computeJitterCount(points);
+    const reversalCount = computeReversalCount(points);
+
+    const movementSmoothness = points.length > 1
+      ? Math.max(0, Math.min(1, 1 - jitterCount / points.length))
+      : 1;
+
+    const hoverDuration = timeToFirstMove;
+
+    return {
+      timeToFirstMove,
+      totalSwipeTime,
+      swipeVelocity: avgVelocity,
+      maxDeviation,
+      trajectoryAUC,
+      jitterCount,
+      reversalCount,
+      peakVelocity,
+      velocityVariance,
+      movementSmoothness,
+      hoverDuration,
+    };
+  }, []);
+
+  return { startTracking, stopTracking, recordPoint, getTrajectory };
+}
+
+// ========================================
+// Internal helpers
+// ========================================
+
+function buildEmptyMetrics(
+  timeToFirstMove: number,
+  totalSwipeTime: number
+): SwipeMetrics {
+  return {
+    timeToFirstMove,
+    totalSwipeTime,
+    swipeVelocity: 0,
+    maxDeviation: 0,
+    trajectoryAUC: 0,
+    jitterCount: 0,
+    reversalCount: 0,
+    peakVelocity: 0,
+    velocityVariance: 0,
+    movementSmoothness: 1,
+    hoverDuration: timeToFirstMove,
+  };
+}
+
+function computeVariance(values: number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const sumSqDiff = values.reduce((acc, v) => acc + (v - mean) ** 2, 0);
+  return sumSqDiff / values.length;
+}
+
+/**
+ * Deviation from straight line between first and last points.
+ * trajectoryAUC = sum of absolute deviations.
+ */
+function computeDeviationMetrics(
+  points: readonly TrajectoryPoint[]
+): { maxDeviation: number; trajectoryAUC: number } {
+  if (points.length < 2) return { maxDeviation: 0, trajectoryAUC: 0 };
+
+  const first = points[0];
+  const last = points[points.length - 1];
+
+  const lineX = last.x - first.x;
+  const lineY = last.y - first.y;
+  const lineLen = Math.sqrt(lineX * lineX + lineY * lineY);
+
+  if (lineLen === 0) return { maxDeviation: 0, trajectoryAUC: 0 };
+
+  let maxDev = 0;
+  let auc = 0;
+
+  for (let i = 1; i < points.length - 1; i++) {
+    const px = points[i].x - first.x;
+    const py = points[i].y - first.y;
+    const cross = Math.abs(px * lineY - py * lineX);
+    const deviation = cross / lineLen;
+    maxDev = Math.max(maxDev, deviation);
+    auc += deviation;
+  }
+
+  return { maxDeviation: maxDev, trajectoryAUC: auc };
+}
+
+/**
+ * Jitter = count of micro direction changes where consecutive dx signs differ.
+ */
+function computeJitterCount(points: readonly TrajectoryPoint[]): number {
+  if (points.length < 3) return 0;
+  let count = 0;
+  for (let i = 2; i < points.length; i++) {
+    const dx1 = points[i - 1].x - points[i - 2].x;
+    const dx2 = points[i].x - points[i - 1].x;
+    if (dx1 * dx2 < 0) count++;
+  }
+  return count;
+}
+
+/**
+ * Reversal = major direction reversals (sustained left-to-right or right-to-left).
+ * Requires at least 3 consecutive same-direction points to count.
+ */
+function computeReversalCount(
+  points: readonly TrajectoryPoint[]
+): number {
+  if (points.length < 4) return 0;
+
+  let currentDirection: 'left' | 'right' | null = null;
+  let sameCount = 0;
+  let reversals = 0;
+
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i].x - points[i - 1].x;
+    if (dx === 0) continue;
+
+    const dir: 'left' | 'right' = dx < 0 ? 'left' : 'right';
+
+    if (dir === currentDirection) {
+      sameCount++;
+    } else {
+      if (currentDirection !== null && sameCount >= 3) {
+        reversals++;
+      }
+      currentDirection = dir;
+      sameCount = 1;
+    }
+  }
+
+  return reversals;
+}

--- a/frontend/src/features/game/hooks/useSwipeGame.ts
+++ b/frontend/src/features/game/hooks/useSwipeGame.ts
@@ -1,0 +1,194 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useAtom } from 'jotai';
+import {
+  gameFlowAtom,
+  roundDataAtom,
+  currentRoundAtom,
+  gameDataAtom,
+} from '@/stores/game';
+import { ROUNDS, TOTAL_ROUNDS } from '@/features/game/data/rounds';
+import type { SwipeRoundConfig } from '@/features/game/data/rounds';
+import type {
+  SwipeDirection,
+  SwipeRoundData,
+  SwipeGameData,
+  GameFlowState,
+} from '@/features/game/types';
+import { useMouseTracker } from './useMouseTracker';
+import { submitGameData } from '@/lib/db';
+
+export interface UseSwipeGameReturn {
+  readonly currentRound: SwipeRoundConfig;
+  readonly roundIndex: number;
+  readonly totalRounds: number;
+  readonly timeRemaining: number;
+  readonly gameState: GameFlowState;
+  readonly startGame: () => void;
+  readonly handleSwipe: (direction: SwipeDirection) => void;
+  readonly handleTimeout: () => void;
+  readonly recordPoint: (x: number, y: number) => void;
+}
+
+export function useSwipeGame(): UseSwipeGameReturn {
+  const [gameState, setGameState] = useAtom(gameFlowAtom);
+  const [rounds, setRounds] = useAtom(roundDataAtom);
+  const [roundIndex, setRoundIndex] = useAtom(currentRoundAtom);
+  const [, setGameData] = useAtom(gameDataAtom);
+
+  const [timeRemaining, setTimeRemaining] = useState(0);
+
+  const tracker = useMouseTracker();
+
+  const timerIdRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const roundStartAtRef = useRef(0);
+  const gameStartAtRef = useRef(0);
+  const isProcessingRef = useRef(false);
+  const completeRoundRef = useRef<(direction: SwipeDirection | 'timeout') => void>(() => {});
+
+  const currentRound = ROUNDS[roundIndex] ?? ROUNDS[0];
+
+  const clearTimer = useCallback(() => {
+    if (timerIdRef.current !== null) {
+      clearInterval(timerIdRef.current);
+      timerIdRef.current = null;
+    }
+  }, []);
+
+  const finishGame = useCallback(
+    async (allRounds: readonly SwipeRoundData[]) => {
+      setGameState('submitting');
+
+      const data: SwipeGameData = {
+        rounds: allRounds,
+        totalDuration: Date.now() - gameStartAtRef.current,
+        completedAt: new Date().toISOString(),
+      };
+
+      setGameData(data);
+
+      const userId = localStorage.getItem('user_id');
+      if (userId) {
+        try {
+          await submitGameData(userId, 1, data);
+        } catch {
+          // Submission failure is non-blocking
+        }
+      }
+
+      setGameState('done');
+    },
+    [setGameState, setGameData]
+  );
+
+  const beginRound = useCallback(
+    (index: number) => {
+      const round = ROUNDS[index];
+      if (!round) return;
+      isProcessingRef.current = false;
+      tracker.startTracking();
+
+      // Start the timer using wall-clock time to avoid drift
+      clearTimer();
+      roundStartAtRef.current = Date.now();
+      setTimeRemaining(round.timeLimit);
+
+      timerIdRef.current = setInterval(() => {
+        const elapsed = (Date.now() - roundStartAtRef.current) / 1000;
+        const remaining = Math.max(0, round.timeLimit - elapsed);
+        setTimeRemaining(remaining);
+
+        if (remaining <= 0) {
+          completeRoundRef.current('timeout');
+        }
+      }, 100);
+    },
+    [tracker, clearTimer]
+  );
+
+  const completeRound = useCallback(
+    (direction: SwipeDirection | 'timeout') => {
+      if (isProcessingRef.current) return;
+      isProcessingRef.current = true;
+      clearTimer();
+
+      const metrics = tracker.stopTracking();
+      const trajectory = tracker.getTrajectory();
+
+      const roundData: SwipeRoundData = {
+        roundNumber: currentRound.roundNumber,
+        direction,
+        metrics,
+        trajectory,
+        startedAt: roundStartAtRef.current,
+        completedAt: Date.now(),
+      };
+
+      const updatedRounds = [...rounds, roundData];
+      setRounds(updatedRounds);
+
+      const nextIndex = roundIndex + 1;
+      if (nextIndex >= TOTAL_ROUNDS) {
+        finishGame(updatedRounds);
+      } else {
+        setRoundIndex(nextIndex);
+        beginRound(nextIndex);
+      }
+    },
+    [
+      clearTimer,
+      tracker,
+      currentRound.roundNumber,
+      rounds,
+      setRounds,
+      roundIndex,
+      setRoundIndex,
+      finishGame,
+      beginRound,
+    ]
+  );
+
+  // Keep ref in sync so the interval can call the latest completeRound
+  useEffect(() => {
+    completeRoundRef.current = completeRound;
+  });
+
+  const startGame = useCallback(() => {
+    setRounds([]);
+    setRoundIndex(0);
+    gameStartAtRef.current = Date.now();
+    setGameState('playing');
+    beginRound(0);
+  }, [setRounds, setRoundIndex, setGameState, beginRound]);
+
+  const handleSwipe = useCallback(
+    (direction: SwipeDirection) => {
+      if (gameState !== 'playing') return;
+      completeRound(direction);
+    },
+    [gameState, completeRound]
+  );
+
+  const handleTimeout = useCallback(() => {
+    if (gameState !== 'playing') return;
+    completeRound('timeout');
+  }, [gameState, completeRound]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => clearTimer();
+  }, [clearTimer]);
+
+  return {
+    currentRound,
+    roundIndex,
+    totalRounds: TOTAL_ROUNDS,
+    timeRemaining,
+    gameState,
+    startGame,
+    handleSwipe,
+    handleTimeout,
+    recordPoint: tracker.recordPoint,
+  };
+}

--- a/frontend/src/stores/game.ts
+++ b/frontend/src/stores/game.ts
@@ -1,0 +1,18 @@
+import { atom } from 'jotai';
+import type {
+  SwipeRoundData,
+  SwipeGameData,
+  GameFlowState,
+} from '@/features/game/types';
+
+/** UI state machine for the game flow */
+export const gameFlowAtom = atom<GameFlowState>('intro');
+
+/** Collected round data (immutable array) */
+export const roundDataAtom = atom<readonly SwipeRoundData[]>([]);
+
+/** Current round index (0-based) */
+export const currentRoundAtom = atom<number>(0);
+
+/** Complete game data (set when game finishes) */
+export const gameDataAtom = atom<SwipeGameData | null>(null);


### PR DESCRIPTION
## Summary
Closes #7 (Wave 3 of #4)

- Framer Motionスワイプカード（drag="x", 回転・透明度変化, 閾値100px）
- マウス軌跡トラッキングhook（11メトリクス: velocity, jitter, deviation, smoothness等）
- ゲームフロー管理（intro→playing→submitting→done）
- ラウンド進行・カウントダウンタイマー（warmup 8s / main 10s / pressure 5s）
- UI部品一式（CardStack, SwipeHint, CountdownBar, RoundIndicator）
- ゲームページ /game
- Jotaiゲーム状態atom（gameFlow, roundData, currentRound, gameData）

## Test plan
- [x] npx tsc --noEmit - Wave 3ファイルエラーゼロ
- [x] pnpm lint - エラーゼロ
- [x] 全コンポーネント 'use client' 指定済み
- [x] framer-motion drag統合
- [x] マウストラッキング11メトリクス実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スワイプゲーム機能を追加しました。複数ラウンドのインタラクティブなカードスワイプゲームで、左右へのスワイプ選択、各ラウンドのカウントダウンタイマー、進捗表示、スワイプガイドを含みます。ゲーム完了後に自動的に結果画面へ遷移します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->